### PR TITLE
(Improve Doc) Import prism.css file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ First, create the plugin and add it to the `plugins` array of your PluginsEditor
 ```JS
 import Prism from 'prismjs';
 import createPrismPlugin from 'draft-js-prism-plugin';
+import "prismjs/themes/prism.css"; // add prism.css to add highlights  
 
 class MyEditor extends React.Component {
   constructor(props) {


### PR DESCRIPTION
The Doc currently doesn't say to import prism CSS to make the highlight magic work. 
Adding the same in this PR.